### PR TITLE
Implement AuthenticationStateProvider as AppAuthStateProvider

### DIFF
--- a/Api/Data/Models/User.cs
+++ b/Api/Data/Models/User.cs
@@ -32,7 +32,7 @@ public class User
         PasswordSalt = passwordSalt;
     }
 
-    private void CreatePasswordHash(string password, out byte[] passwordHash, out byte[] passwordSalt)
+    private static void CreatePasswordHash(string password, out byte[] passwordHash, out byte[] passwordSalt)
     {
         using (var hmac = new HMACSHA512())
         {

--- a/Website/App.razor
+++ b/Website/App.razor
@@ -1,12 +1,18 @@
-﻿<Router AppAssembly="@typeof(App).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-    </Found>
-    <NotFound>
-        <PageTitle>Not found</PageTitle>
-        <LayoutView Layout="@typeof(MainLayout)">
-            <p role="alert">Sorry, there's nothing at this address.</p>
-        </LayoutView>
-    </NotFound>
-</Router>
+﻿<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    Sorry, you are not logged into an account with permissions to see this content.
+                </NotAuthorized>
+            </AuthorizeRouteView>
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+        <NotFound>
+            <PageTitle>Not found</PageTitle>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p role="alert">Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/Website/Program.cs
+++ b/Website/Program.cs
@@ -1,3 +1,5 @@
+global using Microsoft.AspNetCore.Components.Authorization;
+global using SharpScape.Website.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using SharpScape.Website;
@@ -7,5 +9,9 @@ builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped<IAuthTokenProvider, AuthTokenProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider, AppAuthStateProvider>();
+builder.Services.AddOptions();
+builder.Services.AddAuthorizationCore();
 
 await builder.Build().RunAsync();

--- a/Website/Services/AppAuthStateProvider.cs
+++ b/Website/Services/AppAuthStateProvider.cs
@@ -1,0 +1,59 @@
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Json;
+
+namespace SharpScape.Website.Services
+{
+    public class AppAuthStateProvider : AuthenticationStateProvider
+    {
+        private IAuthTokenProvider _tokenProvider;
+        private HttpClient _http;
+
+        public AppAuthStateProvider(IAuthTokenProvider authTokenProvider, HttpClient http)
+        {
+            _tokenProvider = authTokenProvider;
+            _http = http;
+        }
+
+        public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+        {
+            ClaimsIdentity identity;
+            if (_tokenProvider.Token is not null)
+            {
+                identity = new ClaimsIdentity(ParseClaimsFromJwt(_tokenProvider.Token), "jwt");
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _tokenProvider.Token);
+            }
+            else
+            {
+                identity = new ClaimsIdentity();
+                _http.DefaultRequestHeaders.Authorization = null;
+            }
+
+            var user = new ClaimsPrincipal(identity);
+            var state = new AuthenticationState(user);
+
+            NotifyAuthenticationStateChanged(Task.FromResult(state));
+
+            return state;
+        }
+
+        // The following methods shamelessly stolen from SteveSandersonMS as per Patrick God
+        private static IEnumerable<Claim>? ParseClaimsFromJwt(string jwt)
+        {
+            var body = jwt.Split(".")[1];
+            var bodyJson = Base64UrlDecode(body);
+            var keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(bodyJson);
+            return keyValuePairs?.Select(kvp => new Claim(kvp.Key, kvp.Value.ToString()!));
+        }
+
+        private static byte[] Base64UrlDecode(string encoded)
+        {
+            switch (encoded.Length % 4)
+            {
+                case 2: encoded += "=="; break;
+                case 3: encoded += "="; break;
+            }
+            return Convert.FromBase64String(encoded);
+        }
+    }
+}

--- a/Website/Services/AuthTokenProvider.cs
+++ b/Website/Services/AuthTokenProvider.cs
@@ -1,0 +1,14 @@
+namespace SharpScape.Website.Services;
+
+public interface IAuthTokenProvider
+{
+    public string? Token { get; set; }
+}
+
+public class AuthTokenProvider : IAuthTokenProvider
+{
+    public string? Token { get; set; }
+    public AuthTokenProvider()
+    {
+    }
+}

--- a/Website/SharpScape.Website.csproj
+++ b/Website/SharpScape.Website.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.2" PrivateAssets="all" />
   </ItemGroup>

--- a/Website/_Imports.razor
+++ b/Website/_Imports.razor
@@ -5,6 +5,8 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.JSInterop
 @using SharpScape.Website
 @using SharpScape.Website.Shared


### PR DESCRIPTION
Closes #56 

Provides an `IAuthTokenProvider` service to retain a Jwt in memory for the execution time of the application (it will not survive closing & reopening the web browser).  `AppAuthStateProvider` determines whether the token provider has a token, and it will set the authentication state (and default authorization header for use by the default HttpClient service) accordingly.

Currently, there is nothing in the frontend which will receive the token from the Api, populate the AuthTokenProvider service with it, and invoke `AppAuthStateProvider.GetAuthenticationStateAsync()`.  That will be done in addressing #57 