### PR TITLE
Remove unused packages

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.StaticFiles;
 using SharpScape.Api.Services;
 using SharpScape.Api.Data;
 
-using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/Api/SharpScape.Api.csproj
+++ b/Api/SharpScape.Api.csproj
@@ -15,7 +15,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Api/SharpScape.Api.csproj
+++ b/Api/SharpScape.Api.csproj
@@ -21,7 +21,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
   </ItemGroup>

--- a/Shared/SharpScape.Shared.csproj
+++ b/Shared/SharpScape.Shared.csproj
@@ -11,7 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Website/SharpScape.Website.csproj
+++ b/Website/SharpScape.Website.csproj
@@ -14,7 +14,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It turns out that our need for `Newtonsoft.Json` was a misunderstanding: the `JsonSerializationOptions` stuff that Roman needed actually come from `Microsoft.AspNetCore.Mvc`, not Newtonsoft.  Additionally, `Microsoft.EntityFrameworkCore.SqlServer` got added by accident, probably because of a VisualStudio recommendation, but our database context adapters don't make use of it anywhere.

The project still compiles and runs just fine without these packages.