### PR TITLE
Use transient RSA keys for MP login security

### DIFF
--- a/Api/Controllers/MPServerController.cs
+++ b/Api/Controllers/MPServerController.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using SharpScape.Api.Data;
 using SharpScape.Api.Models;
@@ -32,11 +27,12 @@ public class MPServerController : ControllerBase
         _payloadMaxAge = config.GetValue<int>("MPServer:PayloadMaxAge");
     }
 
-    [HttpGet("/api/publickey")]
-    [Produces("text/plain")]
-    public ActionResult<string> GetPublicKey()
+    [HttpGet("transientkey")]
+    [Produces("application/json")]
+    public ActionResult<MPCryptoKey> GetPublicKey()
     {
-        return Ok(_rsaKeyProvider.PublicKeyPem);
+        _crypto.GenerateTransientKey(out Guid keyId, out string x509pub);
+        return Ok(new MPCryptoKey(keyId, x509pub));
     }
 
     [HttpPost("login")]
@@ -44,33 +40,33 @@ public class MPServerController : ControllerBase
     public async Task<ActionResult<GameAvatarInfoDto>> Login([FromBody] MPServerMessageDto request)
     {
         if (! VerifyMPTimestamp(request.Timestamp)) {
-            return BadRequest();
+            return BadRequest("Timestamp invalid");
         }
         
         var timestampedPayload = $"{request.Payload}.{request.Timestamp.ToString()}";
-        if (! VerifyMPSignature(timestampedPayload, request.Signature)) {
-            return BadRequest();
+        if (! _crypto.VerifyMPSignature(timestampedPayload, request.Signature)) {
+            return BadRequest("Signature invalid");
         }
         
-        var data = _rsaKeyProvider.PrivateKey.Decrypt(Convert.FromBase64String(request.Payload), RSAEncryptionPadding.Pkcs1);
+        var data = _crypto.TransientKeyDecrypt(request.KeyId, Convert.FromBase64String(request.Payload));
         if (data is null || data.Length == 0) {
-            return BadRequest("Verified payload was malformed: could not decrypt");
+            return StatusCode(500);
         }
 
         var loginRequest = JsonSerializer.Deserialize<UserLoginDto>(
                 Encoding.UTF8.GetString(data),
                 new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
         if (loginRequest is null || loginRequest.Username is null || loginRequest.Password is null) {
-            return BadRequest("Verified payload was malformed: could not parse JSON");
+            return BadRequest("Login request body malformed");
         }
 
         var user = _context.Users.FirstOrDefault(u => u.Username.ToLower() == loginRequest.Username.ToLower());
         if (user is null) {
-            return BadRequest("Username/Email or Password incorrect");
+            return BadRequest("Username/Email or Password invalid");
         }
         
         if (! _crypto.VerifyPasswordHash(loginRequest.Password, user.PasswordHash, user.PasswordSalt)) {
-            return BadRequest("Username/Email or Password incorrect");
+            return BadRequest("Username/Email or Password invalid");
         }
 
         return Ok(new GameAvatarInfoDto() {
@@ -79,15 +75,6 @@ public class MPServerController : ControllerBase
             GlobalPositionX = 47,
             GlobalPositionY = 92
         });
-    }
-
-    private bool VerifyMPSignature(string data, string signature)
-    {
-        return _rsaKeyProvider.MPServerPublicKey.VerifyHash(
-            SHA256.HashData(Encoding.UTF8.GetBytes(data.TrimEnd())),
-            Convert.FromBase64String(signature),
-            HashAlgorithmName.SHA256,
-            RSASignaturePadding.Pkcs1);
     }
 
     private bool VerifyMPTimestamp(int epochSeconds)

--- a/Api/Services/Crypto.cs
+++ b/Api/Services/Crypto.cs
@@ -17,6 +17,41 @@ public class Crypto
         _rsaKeyProvider = rsaKeyProvider;
     }
 
+    public void GenerateTransientKey(out Guid keyId, out string x509pub)
+    {
+        using (var rsa = new RSACryptoServiceProvider(512))
+        {
+            keyId = Guid.NewGuid();
+            x509pub = Convert.ToBase64String(rsa.ExportSubjectPublicKeyInfo());
+            var secret = rsa.ExportRSAPrivateKey();
+            _rsaKeyProvider.StoreTransientSecret(keyId, secret);
+        }
+    }
+
+    public byte[]? TransientKeyDecrypt(Guid keyId, byte[] payload)
+    {
+        _rsaKeyProvider.CheckoutTransientSecret(keyId, out byte[]? secret);
+        if (secret is null)
+        {
+            return null;
+        }
+
+        byte[]? data = null;
+        try
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportRSAPrivateKey(secret, out int _);
+                data = rsa.Decrypt(payload, false);
+            }
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+        return data;
+    }
+
     public string CreateToken(User user)
     {
         var claims = new List<Claim> {
@@ -48,5 +83,14 @@ public class Crypto
             var computeHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
             return CryptographicOperations.FixedTimeEquals(computeHash, passwordHash);
         }
+    }
+
+    public bool VerifyMPSignature(string data, string signature)
+    {
+        return _rsaKeyProvider.MPServerPublicKey.VerifyHash(
+            SHA256.HashData(Encoding.UTF8.GetBytes(data.TrimEnd())),
+            Convert.FromBase64String(signature),
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
     }
 }

--- a/Api/Services/RsaKeyProvder.cs
+++ b/Api/Services/RsaKeyProvder.cs
@@ -4,15 +4,29 @@ namespace SharpScape.Api.Services;
 
 public class RsaKeyProvider
 {
-    public string PublicKeyPem { get; set; }
+    private Dictionary<Guid, byte[]> _transientSecrets = new();
+    public void StoreTransientSecret(Guid keyId, byte[] secret)
+    {
+        _transientSecrets.Add(keyId, secret);
+    }
+    public void CheckoutTransientSecret(Guid keyId, out byte[]? secret)
+    {
+        if (! _transientSecrets.ContainsKey(keyId))
+        {
+            secret = null;
+            return;
+        }
+        secret = (byte[]) _transientSecrets[keyId]!;
+        _transientSecrets.Remove(keyId);
+    }
+
     public RSA PublicKey { get; set; } = RSA.Create();
     public RSA PrivateKey { get; set; } = RSA.Create();
     public RSA MPServerPublicKey { get; set; } = RSA.Create();
 
     public RsaKeyProvider(IConfiguration config)
     {
-        PublicKeyPem = File.ReadAllText(config.GetSection("Jwt:RSA:PublicKey").Value);
-        PublicKey.ImportFromPem(PublicKeyPem);
+        PublicKey.ImportFromPem(File.ReadAllText(config.GetSection("Jwt:RSA:PublicKey").Value));
         PrivateKey.ImportFromPem(File.ReadAllText(config.GetSection("Jwt:RSA:PrivateKey").Value));
         MPServerPublicKey.ImportFromPem(File.ReadAllText(config.GetSection("MPServer:RSA:PublicKey").Value));
     }

--- a/Shared/MPServerDto.cs
+++ b/Shared/MPServerDto.cs
@@ -2,6 +2,7 @@ namespace SharpScape.Shared.Dto;
 
 public class MPServerMessageDto
 {
+    public Guid KeyId { get; set; }
     public string Payload { get; set; }
     public int Timestamp { get; set; }
     public string Signature { get; set; }
@@ -14,4 +15,15 @@ public class GameAvatarInfoDto
     public string Avatar { get; set; }
     public float GlobalPositionX { get; set; }
     public float GlobalPositionY { get; set; }
+}
+
+public class MPCryptoKey
+{
+    public Guid KeyId { get; set; }
+    public string X509Pub { get; set; }
+    public MPCryptoKey(Guid keyId, string x509pub)
+    {
+        KeyId = keyId;
+        X509Pub = x509pub;
+    }
 }


### PR DESCRIPTION
Encrypting user login credentials against SharpScape's static RSA public key is bad for user trust and security.
 - There exists the theoretical possibility that we can log the login request payloads that come from the MP Server.
 - We, the developers, have access to the RSA private key that can unlock the encrypted credentials.
 - Thus it is within our grasp to compromise user credentials.

Using single-use, transient RSA key pairs for *each* game login request ensures that ***even if*** we log the game login request payloads, the keys used for its decryption have been freed from memory, and the credentials cannot be compromised.