### PR TITLE
AES encrypt MP login payload with RSA secured key

### DIFF
--- a/Api/Services/RsaKeyProvder.cs
+++ b/Api/Services/RsaKeyProvder.cs
@@ -5,19 +5,25 @@ namespace SharpScape.Api.Services;
 public class RsaKeyProvider
 {
     private Dictionary<Guid, byte[]> _transientSecrets = new();
-    public void StoreTransientSecret(Guid keyId, byte[] secret)
+    public void GetNewTransientKey(out Guid keyId, out string x509pub)
     {
-        _transientSecrets.Add(keyId, secret);
+        using (var rsa = new RSACryptoServiceProvider(1024))
+        {
+            keyId = Guid.NewGuid();
+            x509pub = Convert.ToBase64String(rsa.ExportSubjectPublicKeyInfo());
+            var secret = rsa.ExportRSAPrivateKey();
+            _transientSecrets.Add(keyId, secret);
+        }
     }
-    public void CheckoutTransientSecret(Guid keyId, out byte[]? secret)
+    public byte[]? CheckoutTransientSecret(Guid keyId)
     {
         if (! _transientSecrets.ContainsKey(keyId))
         {
-            secret = null;
-            return;
+            return null;
         }
-        secret = (byte[]) _transientSecrets[keyId]!;
+        var secret = (byte[]) _transientSecrets[keyId]!;
         _transientSecrets.Remove(keyId);
+        return secret;
     }
 
     public RSA PublicKey { get; set; } = RSA.Create();

--- a/Shared/MPServerDto.cs
+++ b/Shared/MPServerDto.cs
@@ -1,19 +1,17 @@
 namespace SharpScape.Shared.Dto;
 
-public class MPServerMessageDto
+public class MPServerLoginDto
 {
-    public Guid KeyId { get; set; }
     public string Payload { get; set; }
     public int Timestamp { get; set; }
     public string Signature { get; set; }
 }
 
-public class GameAvatarInfoDto
+public class MPUniqueSecret
 {
-    public UserInfoDto UserInfo { get; set; }
-    public string SpriteName { get; set; }
-    public float GlobalPositionX { get; set; }
-    public float GlobalPositionY { get; set; }
+    public Guid KeyId { get; set; }
+    public string SecureKey { get; set; }
+    public string Payload { get; set; }
 }
 
 public class MPCryptoKey
@@ -25,4 +23,12 @@ public class MPCryptoKey
         KeyId = keyId;
         X509Pub = x509pub;
     }
+}
+
+public class GameAvatarInfoDto
+{
+    public UserInfoDto UserInfo { get; set; }
+    public string SpriteName { get; set; }
+    public float GlobalPositionX { get; set; }
+    public float GlobalPositionY { get; set; }
 }


### PR DESCRIPTION
Previously, purely RSA was used to encrypt/decrypt user login credentials.
As a result, user credentials were subject to hard length limits, where
exceeding the block size of the RSA engine would throw an out of bounds
exception.  The RSA algorithm by itself is not well suited to arbitrary-
length payload encryption.  Enter AES-CBC, which can do this job.  It
requires an additional key of its own, to be generated by the sender (the
MP client), yet since it's symmetrical it must be asymmetrically secured,
which is the new role of the RSA transient key pair.